### PR TITLE
Fix/issue 1 fernet b64 encoding

### DIFF
--- a/microservice.py
+++ b/microservice.py
@@ -30,7 +30,7 @@ def main():
                         "public": public_key.save_pkcs1().decode('utf-8'),
                         "private": private_key.save_pkcs1().decode('utf-8')
                     },
-                    "fernet": base64.b64encode(fernet_key).decode('utf-8')
+                    "fernet": fernet_key.decode('utf-8')
                 }
                 print("Generated new RSA and Fernet keys.")
 
@@ -39,7 +39,7 @@ def main():
                 fernet_key_b64 = message["fernet"]
                 rsa_public_pem = message["rsa_public"]
 
-                fernet_key_bytes = base64.b64decode(fernet_key_b64)
+                fernet_key_bytes = fernet_key_b64.encode('utf-8')
                 public_key = rsa.PublicKey.load_pkcs1(rsa_public_pem.encode('utf-8'))
                 encrypted_fernet = rsa.encrypt(fernet_key_bytes, public_key)
                 
@@ -58,7 +58,7 @@ def main():
                 decrypted_fernet = rsa.decrypt(encrypted_fernet_bytes, private_key)
 
                 response = {
-                    "fernet": base64.b64encode(decrypted_fernet).decode('utf-8')
+                    "fernet": decrypted_fernet.decode('utf-8')
                 }
                 print("Decrypted Fernet key.")
 


### PR DESCRIPTION
I removed the unnecessary base64-encoding/decoding that was causing issues for later encryption using the Fernet key.